### PR TITLE
ABC Bounds

### DIFF
--- a/rekallpy/rekall/bounds/abstract_bounds.py
+++ b/rekallpy/rekall/bounds/abstract_bounds.py
@@ -1,8 +1,9 @@
 """This module defines the ``Bounds`` class, which all bounds should inherit
 from.
 """
+from abc import ABC, abstractmethod
 
-class Bounds:
+class Bounds(ABC):
     """
     The ``Bounds`` class is a simple wrapper around a dictionary. Typically,
     the keys in this dictionary should represent physical bounds, like ``t1``,
@@ -187,22 +188,22 @@ class Bounds:
         """Converts the bounds to a JSON object."""
         return self.data
 
+    @abstractmethod
     def __lt__(self, other):
         """Method to compare two Bounds. Child classes should implement
         this."""
-        pass
 
+    @abstractmethod
     def __repr__(self):
         """Method to get a string representation of a Bound. Child classes
         should implement this."""
-        pass
 
+    @abstractmethod
     def primary_axis(self):
         """Method to get the primary axis of a Bound for optimizations. Child
         classes should implement this."""
-        pass
 
+    @abstractmethod
     def copy(self):
         """Method to get another Bound that has the same data as this Bound.
         Child classes should implement this."""
-        pass

--- a/rekallpy/test/test_bounds.py
+++ b/rekallpy/test/test_bounds.py
@@ -59,6 +59,9 @@ class TestBounds(unittest.TestCase):
             def __init__(self, t1, t2, x1, x2):
                 self.data = { 't1': t1, 't2': t2, 'x1': x1, 'x2': x2 }
 
+            def __repr__(self):
+                pass
+
             def __lt__(self, other):
                 return ((self['t1'], self['t2'], self['x1'], self['x2']) <
                         (other['t1'], other['t2'], other['x1'], other['x2']))
@@ -68,6 +71,9 @@ class TestBounds(unittest.TestCase):
 
             def X(pred):
                 return Bounds.cast({ 't1': 'x1', 't2': 'x2' })(pred)
+            
+            def copy(self):
+                pass
 
         bounds1 = Bounds2D(0, 1, 0.5, 0.7)
         bounds2 = Bounds2D(2, 3, 0.4, 0.6)


### PR DESCRIPTION
Imo, gives a better semantic understanding of `Bounds` but also requires child classes to define any `abstractmethod`.