### PR TITLE
Bug Fix: IntervalSet Join with window

### DIFF
--- a/rekallpy/rekall/interval_set.py
+++ b/rekallpy/rekall/interval_set.py
@@ -241,7 +241,7 @@ class IntervalSet:
                     if self_start - window <= other_end:
                         if new_start_index is None:
                             new_start_index = idx + start_index
-                        if other_start - window > other_end:
+                        if other_start - window > self_end:
                             break
                         intervals_in_other.append(intrvlother)
                 if new_start_index is None:


### PR DESCRIPTION
I'm using Join Operation of Rekall, and found that it is pretty slow. Then I went to the source code and found that the function `IntervalSet._map_with_other_within_primary_axis_window` used by `IntervalSet.join`  may have a bug. 

Here is the location of the bug:
https://github.com/scanner-research/rekall/blob/master/rekallpy/rekall/interval_set.py#L244

I think the `other_end` in this line of code should be `self_end`, right?
